### PR TITLE
Avoid sending 304s in Symfony kernel.debug mode

### DIFF
--- a/NotModified/services.xml
+++ b/NotModified/services.xml
@@ -7,6 +7,7 @@
         <service id="Webfactory\HttpCacheBundle\NotModified\EventListener" class="Webfactory\HttpCacheBundle\NotModified\EventListener" public="true">
             <argument type="service" id="annotation_reader" />
             <argument type="service" id="service_container" />
+            <argument>%kernel.debug%</argument>
             <tag name="kernel.event_listener" event="kernel.controller" priority="-200" />
             <tag name="kernel.event_listener" event="kernel.response" />
         </service>


### PR DESCRIPTION
This may be confusing for developers, since changes to e. g. Twig templates may not become visible, or requests even completely bypass controllers, changes to DIC configuration or similar.

Almost the same code as we have here:

https://github.com/webfactory/WebfactoryWfdMetaBundle/blob/7592793915d7d9b096a6c49bbdc06acae1bd7e90/Caching/EventListener.php#L60-L70
