### PR TITLE
Update actions/cache to v3

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -22,7 +22,7 @@ jobs:
                   php-version: ${{ env.PHP_VERSION }}
                   tools: composer:v2
             -   uses: actions/checkout@v3
-            -   uses: actions/cache@v2
+            -   uses: actions/cache@v3
                 with:
                     path: vendor
                     key: composer-${{ runner.os }}-${{ env.PHP_VERSION }}-${{ hashFiles('composer.json') }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
                 with:
                   php-version: ${{ matrix.php-version }}
                   tools: composer:v2
-            -   uses: actions/cache@v2
+            -   uses: actions/cache@v3
                 with:
                     path: vendor
                     key: composer-${{ runner.os }}-${{ matrix.php-version }}-${{ matrix.symfony-locked-version }}-${{ matrix.dependency-version }}-${{ hashFiles('composer.json') }}


### PR DESCRIPTION
This addresses the deprecation described at https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
