### PR TITLE
Use newer PHP syntax, add types (Case 177753)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         {
             "name": "webfactory GmbH",
             "email": "info@webfactory.de",
-            "homepage": "http://www.webfactory.de",
+            "homepage": "https://www.webfactory.de",
             "role": "Developer"
         }
     ],

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.8/phpunit.xsd">
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd">
     <testsuites>
         <testsuite name="Library Test Suite">
             <directory>tests</directory>

--- a/src/NotModified/Attribute/ReplaceWithNotModifiedResponse.php
+++ b/src/NotModified/Attribute/ReplaceWithNotModifiedResponse.php
@@ -24,21 +24,14 @@ use Webfactory\HttpCacheBundle\NotModified\LastModifiedDeterminator;
 #[Attribute(Attribute::TARGET_METHOD)]
 final class ReplaceWithNotModifiedResponse
 {
-    /** @var array */
-    private $parameters;
-
     /** @var LastModifiedDeterminator[] */
-    private $lastModifiedDeterminators;
+    private array $lastModifiedDeterminators;
+    private ContainerInterface $container;
+    private ?DateTime $lastModified = null;
 
-    /** @var ContainerInterface */
-    private $container;
-
-    /** @var DateTime|null */
-    private $lastModified;
-
-    public function __construct(array $parameters)
-    {
-        $this->parameters = $parameters;
+    public function __construct(
+        private readonly array $parameters,
+    ) {
     }
 
     /**

--- a/src/NotModified/Attribute/ReplaceWithNotModifiedResponse.php
+++ b/src/NotModified/Attribute/ReplaceWithNotModifiedResponse.php
@@ -34,10 +34,7 @@ final class ReplaceWithNotModifiedResponse
     ) {
     }
 
-    /**
-     * @return DateTime|null
-     */
-    public function determineLastModified(Request $request)
+    public function determineLastModified(Request $request): ?DateTime
     {
         $this->initialiseLastModifiedDeterminators();
 
@@ -51,12 +48,12 @@ final class ReplaceWithNotModifiedResponse
         return $this->lastModified;
     }
 
-    public function setContainer(ContainerInterface $container)
+    public function setContainer(ContainerInterface $container): void
     {
         $this->container = $container;
     }
 
-    private function initialiseLastModifiedDeterminators()
+    private function initialiseLastModifiedDeterminators(): void
     {
         if (0 === count($this->parameters)) {
             throw new RuntimeException('The attribute '.get_class($this).' has to be parametrised with LastModifiedDeterminators.');

--- a/src/NotModified/EventListener.php
+++ b/src/NotModified/EventListener.php
@@ -44,7 +44,7 @@ final class EventListener
      * header in the request, replace the determined controller action with a minimal action that just returns an
      * "empty" response with a 304 Not Modified HTTP status code.
      */
-    public function onKernelController(ControllerEvent $event)
+    public function onKernelController(ControllerEvent $event): void
     {
         $annotation = $this->findAnnotation($event->getController());
         if (!$annotation) {
@@ -80,7 +80,7 @@ final class EventListener
      * If a last modified date was determined for the current (master or sub) request, set it to the response so the
      * client can use it for the "If-Modified-Since" header in subsequent requests.
      */
-    public function onKernelResponse(ResponseEvent $event)
+    public function onKernelResponse(ResponseEvent $event): void
     {
         $request = $event->getRequest();
         $response = $event->getResponse();
@@ -92,10 +92,8 @@ final class EventListener
 
     /**
      * @param $controllerCallable callable PHP callback pointing to the method to reflect on.
-     *
-     * @return ?ReplaceWithNotModifiedResponse The annotation, if found. Null otherwise.
      */
-    private function findAnnotation(callable $controllerCallable)
+    private function findAnnotation(callable $controllerCallable): ?ReplaceWithNotModifiedResponse
     {
         if (!is_array($controllerCallable)) {
             return null;

--- a/src/NotModified/EventListener.php
+++ b/src/NotModified/EventListener.php
@@ -24,27 +24,18 @@ use Webfactory\HttpCacheBundle\NotModified\Attribute\ReplaceWithNotModifiedRespo
  */
 final class EventListener
 {
-    /** @var ContainerInterface */
-    private $container;
-
     /**
      * Maps (master and sub) requests to their corresponding last modified date. This date is determined by the
      * ReplaceWithNotModifiedResponse annotation of the corresponding controller's action.
-     *
-     * @var SplObjectStorage
      */
-    private $lastModified;
+    private SplObjectStorage $lastModified;
 
-    /**
-     * @var bool Symfony kernel.debug mode
-     */
-    private $debug;
-
-    public function __construct(ContainerInterface $container, bool $debug = false)
-    {
-        $this->container = $container;
+    public function __construct(
+        private readonly ContainerInterface $container,
+        // Symfony kernel.debug mode
+        private readonly bool $debug = false,
+    ) {
         $this->lastModified = new SplObjectStorage();
-        $this->debug = $debug;
     }
 
     /**

--- a/src/NotModified/services.xml
+++ b/src/NotModified/services.xml
@@ -2,7 +2,7 @@
 
 <container xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xmlns="http://symfony.com/schema/dic/services"
-           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+           xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
         <service id="Webfactory\HttpCacheBundle\NotModified\EventListener" class="Webfactory\HttpCacheBundle\NotModified\EventListener" public="true">
             <argument type="service" id="service_container" />

--- a/tests/NotModified/Attribute/ReplaceWithNotModifiedResponseTest.php
+++ b/tests/NotModified/Attribute/ReplaceWithNotModifiedResponseTest.php
@@ -117,14 +117,14 @@ final class FakeLastModifiedDeterminatorWithoutInterface
 
 final class MyLastModifedDeterminator implements LastModifiedDeterminator
 {
-    private \DateTime $lastModified;
+    private DateTime $lastModified;
 
     public function __construct(?DateTime $lastModified = null)
     {
         $this->lastModified = $lastModified ?: DateTime::createFromFormat('U', time());
     }
 
-    public function getLastModified(Request $request)
+    public function getLastModified(Request $request): DateTime
     {
         return $this->lastModified;
     }

--- a/tests/NotModified/Attribute/ReplaceWithNotModifiedResponseTest.php
+++ b/tests/NotModified/Attribute/ReplaceWithNotModifiedResponseTest.php
@@ -117,8 +117,7 @@ final class FakeLastModifiedDeterminatorWithoutInterface
 
 final class MyLastModifedDeterminator implements LastModifiedDeterminator
 {
-    /** @var DateTime */
-    private $lastModified;
+    private \DateTime $lastModified;
 
     public function __construct(?DateTime $lastModified = null)
     {

--- a/tests/NotModified/EventListenerTest.php
+++ b/tests/NotModified/EventListenerTest.php
@@ -33,27 +33,15 @@ final class EventListenerTest extends TestCase
 {
     /**
      * System under test.
-     *
-     * @var EventListener
      */
-    private $eventListener;
+    private EventListener $eventListener;
 
-    /** @var ContainerInterface|MockObject */
-    private $container;
-
-    /** @var ControllerEvent|MockObject */
-    private $filterControllerEvent;
-
-    /** @var Request */
-    private $request;
-
-    /** @var Response */
-    private $response;
-
+    private ContainerInterface&MockObject $container;
+    private ControllerEvent|MockObject $filterControllerEvent;
+    private Request $request;
+    private Response $response;
     private $callable;
-
-    /** @var KernelInterface|MockObject */
-    private $kernel;
+    private KernelInterface&MockObject $kernel;
 
     protected function setUp(): void
     {


### PR DESCRIPTION
Use constructor property promotion, add property types, readonly modifier and return types where it would not result in a BC break (e.g. refrain from adding return types to the public interface).

Update URLs for external references.