### PR TITLE
Read attributes as provided by the event object, and pass on attributes to other event handlers (Case 177753)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "symfony/dependency-injection": "^5.0 | ^6.0 | ^7.0",
         "symfony/deprecation-contracts": "^2.0|^3.0",
         "symfony/http-foundation": "^5.0 | ^6.0 | ^7.0",
-        "symfony/http-kernel": "^6.2 | ^7.0"
+        "symfony/http-kernel": "^6.4 | ^7.0"
     },
 
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "symfony/dependency-injection": "^5.0 | ^6.0 | ^7.0",
         "symfony/deprecation-contracts": "^2.0|^3.0",
         "symfony/http-foundation": "^5.0 | ^6.0 | ^7.0",
-        "symfony/http-kernel": "^5.3 | ^6.0 | ^7.0"
+        "symfony/http-kernel": "^6.2 | ^7.0"
     },
 
     "require-dev": {

--- a/tests/NotModified/EventListenerTest.php
+++ b/tests/NotModified/EventListenerTest.php
@@ -11,6 +11,7 @@ namespace Webfactory\HttpCacheBundle\Tests\NotModified;
 
 use Closure;
 use DateTime;
+use Error;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -198,7 +199,7 @@ final class EventListenerTest extends TestCase
     /** @test */
     public function onKernelControllerThrowsExceptionIfAttributeIsFoundMoreThanOnce(): void
     {
-        self::expectException(\Error::class);
+        self::expectException(Error::class);
         self::expectExceptionMessageMatches('/ReplaceWithNotModifiedResponse/');
 
         $this->exerciseOnKernelController([DummyController::class, 'actionWithMoreThanOneAttribute']);

--- a/tests/NotModified/EventListenerTest.php
+++ b/tests/NotModified/EventListenerTest.php
@@ -195,6 +195,15 @@ final class EventListenerTest extends TestCase
         self::assertNotEmpty($this->filterControllerEvent->getAttributes());
     }
 
+    /** @test */
+    public function onKernelControllerThrowsExceptionIfAttributeIsFoundMoreThanOnce(): void
+    {
+        self::expectException(\Error::class);
+        self::expectExceptionMessageMatches('/ReplaceWithNotModifiedResponse/');
+
+        $this->exerciseOnKernelController([DummyController::class, 'actionWithMoreThanOneAttribute']);
+    }
+
     private function exerciseOnKernelController(array $callable): void
     {
         $this->callable = $callable;
@@ -246,6 +255,13 @@ final class DummyController
 
     #[ReplaceWithNotModifiedResponse([FixedDateAgoModifiedLastModifiedDeterminator::class])]
     public static function fixedDateAgoModifiedLastModifiedDeterminatorAction(): Response
+    {
+        return new Response();
+    }
+
+    #[ReplaceWithNotModifiedResponse([AbstainingLastModifiedDeterminator::class])]
+    #[ReplaceWithNotModifiedResponse([OneDayAgoModifiedLastModifiedDeterminator::class])]
+    public static function actionWithMoreThanOneAttribute(): Response
     {
         return new Response();
     }


### PR DESCRIPTION
This adapts https://github.com/webfactory/WebfactoryWfdMetaBundle/pull/53:

> This PR uses the new API introduced in https://github.com/symfony/symfony/pull/46001 to read controller attributes through the `ControllerEvent`, and to make them available to other event handlers when replacing the controller.
>
> This is necessary when using the `Send304IfNotModified` attribute in combination with `\Symfony\Component\HttpKernel\Attribute\Cache`. Without this change, `\Symfony\Component\HttpKernel\EventListener\CacheAttributeListener` will not set `Cache` headers accordingly. The result is that you may get `304 Not Modified` responses on conditional requests with `If-Modified-Since`, but these are treated as `stale/cache` only in the HttpCache and have a `Cache-Control: must-revalidate, private` header.

And adds some tests.