### PR TITLE
Vermeide Deprecation

### DIFF
--- a/src/DependencyInjection/WebfactoryHttpCacheExtension.php
+++ b/src/DependencyInjection/WebfactoryHttpCacheExtension.php
@@ -4,8 +4,8 @@ namespace Webfactory\HttpCacheBundle\DependencyInjection;
 
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 class WebfactoryHttpCacheExtension extends Extension
 {


### PR DESCRIPTION
...durch Nutzung von `Symfony\Component\DependencyInjection\Extension\Extension` an Stelle von `Symfony\Component\HttpKernel\DependencyInjection\Extension`.
