### PR TITLE
Relax LastModifiedDeterminator interface to use DateTimeInterface as return type

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ final class PostsLastModifiedDeterminator implements LastModifiedDeterminator
         private readonly BlogPostRepository $blogPostRepository,
     ) {
     
-    public function getLastModified(Request $request): ?\DateTime
+    public function getLastModified(Request $request): ?\DateTimeInterface
     {
         $post = $this->blogPostRepository->findLatest();
         

--- a/src/DependencyInjection/WebfactoryHttpCacheExtension.php
+++ b/src/DependencyInjection/WebfactoryHttpCacheExtension.php
@@ -7,6 +7,10 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 
+/**
+ * @internal
+ * @psalm-internal Webfactory\HttpCacheBundle
+ */
 class WebfactoryHttpCacheExtension extends Extension
 {
     public function load(array $configs, ContainerBuilder $container): void

--- a/src/NotModified/Attribute/ReplaceWithNotModifiedResponse.php
+++ b/src/NotModified/Attribute/ReplaceWithNotModifiedResponse.php
@@ -10,7 +10,7 @@
 namespace Webfactory\HttpCacheBundle\NotModified\Attribute;
 
 use Attribute;
-use DateTime;
+use DateTimeInterface;
 use RuntimeException;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -27,14 +27,18 @@ final class ReplaceWithNotModifiedResponse
     /** @var LastModifiedDeterminator[] */
     private array $lastModifiedDeterminators;
     private ContainerInterface $container;
-    private ?DateTime $lastModified = null;
+    private ?DateTimeInterface $lastModified = null;
 
     public function __construct(
         private readonly array $parameters,
     ) {
     }
 
-    public function determineLastModified(Request $request): ?DateTime
+    /**
+     * @internal
+     * @psalm-internal Webfactory\HttpCacheBundle
+     */
+    public function determineLastModified(Request $request): ?DateTimeInterface
     {
         $this->initialiseLastModifiedDeterminators();
 
@@ -48,6 +52,10 @@ final class ReplaceWithNotModifiedResponse
         return $this->lastModified;
     }
 
+    /**
+     * @internal
+     * @psalm-internal Webfactory\HttpCacheBundle
+     */
     public function setContainer(ContainerInterface $container): void
     {
         $this->container = $container;

--- a/src/NotModified/EventListener.php
+++ b/src/NotModified/EventListener.php
@@ -20,6 +20,9 @@ use Webfactory\HttpCacheBundle\NotModified\Attribute\ReplaceWithNotModifiedRespo
  * Symfony EventListener for adding a "last modified" header to the response on the one hand. On the other hand, it
  * replaces the execution of a controller action with a Not Modified HTTP response, if no newer "last modified" date is
  * determined than the one in the header of a subsequent request.
+ *
+ * @internal
+ * @psalm-internal Webfactory\HttpCacheBundle
  */
 final class EventListener
 {

--- a/src/NotModified/LastModifiedDeterminator.php
+++ b/src/NotModified/LastModifiedDeterminator.php
@@ -9,7 +9,7 @@
 
 namespace Webfactory\HttpCacheBundle\NotModified;
 
-use DateTime;
+use DateTimeInterface;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -22,7 +22,7 @@ use Symfony\Component\HttpFoundation\Request;
 interface LastModifiedDeterminator
 {
     /**
-     * @return DateTime|null
+     * @return ?DateTimeInterface
      */
     public function getLastModified(Request $request);
 }

--- a/tests/NotModified/Attribute/ReplaceWithNotModifiedResponseTest.php
+++ b/tests/NotModified/Attribute/ReplaceWithNotModifiedResponseTest.php
@@ -10,6 +10,7 @@
 namespace Webfactory\HttpCacheBundle\Tests\NotModified\Attribute;
 
 use DateTime;
+use DateTimeInterface;
 use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
@@ -103,14 +104,14 @@ final class FakeLastModifiedDeterminatorWithoutInterface
 
 final class MyLastModifedDeterminator implements LastModifiedDeterminator
 {
-    private DateTime $lastModified;
+    private ?DateTimeInterface $lastModified;
 
-    public function __construct(?DateTime $lastModified = null)
+    public function __construct(?DateTimeInterface $lastModified = null)
     {
         $this->lastModified = $lastModified ?: DateTime::createFromFormat('U', time());
     }
 
-    public function getLastModified(Request $request): DateTime
+    public function getLastModified(Request $request): ?DateTimeInterface
     {
         return $this->lastModified;
     }

--- a/tests/NotModified/EventListenerTest.php
+++ b/tests/NotModified/EventListenerTest.php
@@ -11,6 +11,7 @@ namespace Webfactory\HttpCacheBundle\Tests\NotModified;
 
 use Closure;
 use DateTime;
+use DateTimeInterface;
 use Error;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
@@ -269,7 +270,7 @@ final class DummyController
 
 final class AbstainingLastModifiedDeterminator implements LastModifiedDeterminator
 {
-    public function getLastModified(Request $request): ?DateTime
+    public function getLastModified(Request $request): ?DateTimeInterface
     {
         return null;
     }
@@ -277,7 +278,7 @@ final class AbstainingLastModifiedDeterminator implements LastModifiedDeterminat
 
 final class OneDayAgoModifiedLastModifiedDeterminator implements LastModifiedDeterminator
 {
-    public function getLastModified(Request $request): DateTime
+    public function getLastModified(Request $request): ?DateTimeInterface
     {
         return DateTime::createFromFormat('U', time() - 86400);
     }
@@ -285,7 +286,7 @@ final class OneDayAgoModifiedLastModifiedDeterminator implements LastModifiedDet
 
 final class FixedDateAgoModifiedLastModifiedDeterminator implements LastModifiedDeterminator
 {
-    public function getLastModified(Request $request): DateTime
+    public function getLastModified(Request $request): ?DateTimeInterface
     {
         return new DateTime('2000-01-01');
     }


### PR DESCRIPTION
This relaxes the interface that clients need to implement to return `DateTimeInterface` instead of `DateTime`.

For methods like `ReplaceWithNotModifiedResponse::determineLastModified()`, a relaxed return type technically is a BC break. However, that method was never meant to be used by outside clients, it is part of the inner workings of this bundle. To state this more clearly for the future, `@internal` docblocks are added as well.